### PR TITLE
fix: replace placeholder apple_touch_icon / safari_pinned_tab URLs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -50,8 +50,8 @@ params:
     favicon: https://avatars.githubusercontent.com/u/13862551?v=4
     favicon16x16: https://avatars.githubusercontent.com/u/13862551?v=4
     favicon32x32: https://avatars.githubusercontent.com/u/13862551?v=4
-    apple_touch_icon: "<link / abs url>"
-    safari_pinned_tab: "<link / abs url>"
+    apple_touch_icon: https://avatars.githubusercontent.com/u/13862551?v=4
+    safari_pinned_tab: https://avatars.githubusercontent.com/u/13862551?v=4
 
   label:
     text: "🌏 Masatoshi Nagahama"


### PR DESCRIPTION
## Summary

`config.yml` のパラメータに `<link / abs url>` というプレースホルダ文字列が残ったままになっており、Hugo がそのまま URL エンコードして `<link rel=apple-touch-icon href="https://mnagaa.github.io/%3Clink%20/%20abs%20url%3E">` という壊れた link タグを出力していた。

その結果ブラウザが既定の `/apple-touch-icon.png` にフォールバックして 404 を出していたため、favicon と同じ GitHub アバター URL を使うように修正。

```diff
-    apple_touch_icon: "<link / abs url>"
-    safari_pinned_tab: "<link / abs url>"
+    apple_touch_icon: https://avatars.githubusercontent.com/u/13862551?v=4
+    safari_pinned_tab: https://avatars.githubusercontent.com/u/13862551?v=4
```

`safari_pinned_tab` は本来モノクロ SVG が望ましいが、当面は 404 を消すための暫定対応として PNG アバターで代用。専用 SVG を作って `static/` に置きたくなったら別途差し替え。

## Test plan

- [x] `hugo --quiet` でビルド成功
- [x] 生成された `public/profile/index.html` で `<link rel=apple-touch-icon href="https://avatars.githubusercontent.com/u/13862551?v=4">` を確認
- [ ] デプロイ後、DevTools Network タブで `/apple-touch-icon.png` への 404 が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)